### PR TITLE
fix: buffer diagnostics in windows

### DIFF
--- a/lua/telescope/_extensions/coc.lua
+++ b/lua/telescope/_extensions/coc.lua
@@ -480,6 +480,9 @@ local diagnostics = function(opts)
   local buf_names = {}
   local current_buf = api.nvim_get_current_buf()
   local current_filename = api.nvim_buf_get_name(current_buf)
+  if vim.fn.has("win32") then
+    current_filename = string.lower(string.sub(current_filename, 1, 1)) .. string.sub(current_filename, 2)
+  end
   if opts.get_all then
     local bufs = api.nvim_list_bufs()
     for _, bn in ipairs(bufs) do


### PR DESCRIPTION
<img width="972" alt="Snipaste_2023-02-16_21-27-58" src="https://user-images.githubusercontent.com/38285270/219377825-6d622857-4fd1-41f8-bc19-4d6f51863ec0.png">

#### 原因
diagnostics() 函数里
**current_filename** 盘符是大写的，例如 D:\foo.c
但 **d.file** 是小写的，如 d:\foo.c
导致 **d.file == current_filename** 为 false
#### 我的解决方法
在 **...\telescope-coc.nvim\lua\telescope\_extensions\coc.lua**
```lua
  local current_buf = api.nvim_get_current_buf()
  local current_filename = api.nvim_buf_get_name(current_buf)
```
后面增加一小段把 **current_filename** 的盘符改为小写
```lua
  if vim.fn.has("win32") then
    current_filename = string.lower(string.sub(current_filename, 1, 1)) .. string.sub(current_filename, 2)
  end
```
然后成功了

<img width="972" alt="Snipaste_2023-02-16_21-40-27" src="https://user-images.githubusercontent.com/38285270/219380545-ab4403ba-891a-40a5-a32b-6711ef132d81.png">
