### PR TITLE
perf(locations_to_items): a better way to load file content

### DIFF
--- a/lua/telescope/_extensions/coc.lua
+++ b/lua/telescope/_extensions/coc.lua
@@ -48,10 +48,18 @@ local locations_to_items = function(locs)
       l.range = l.targetRange
     end
     local bufnr = vim.uri_to_bufnr(l.uri)
-    vim.fn.bufload(bufnr)
+    local is_loaded = api.nvim_buf_is_loaded(bufnr)
+    local line = ''
+
+    if not is_loaded then
+      local content = vim.fn.readfile(vim.uri_to_fname(l.uri))
+      line = content[l.range.start.line + 1]
+    else
+      line = (api.nvim_buf_get_lines(bufnr, l.range.start.line, l.range.start.line + 1, false) or { '' })[1]
+    end
+
     local filename = vim.uri_to_fname(l.uri)
     local row = l.range.start.line
-    local line = (api.nvim_buf_get_lines(bufnr, row, row + 1, false) or { '' })[1]
     items[#items + 1] = {
       filename = filename,
       lnum = row + 1,


### PR DESCRIPTION
Using `vim.fn.bufload(bufnr)` could cause performance loss. I think it would be a better way to read file content by using `vim.fn.readfile` to read the unopened file and using  `vim.api.nvim_buf_get_lines` for opened buffer.