### PR TITLE
feat: configurable timeout for coc commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ require("telescope").setup({
         theme = 'ivy',
         prefer_locations = true, -- always use Telescope locations to preview definitions/declarations/implementations etc
         push_cursor_on_edit = true, -- save the cursor position to jump back in the future
+        timeout = 3000, -- (optional) timeout for coc commands
     }
   },
 })

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ require("telescope").setup({
         theme = 'ivy',
         prefer_locations = true, -- always use Telescope locations to preview definitions/declarations/implementations etc
         push_cursor_on_edit = true, -- save the cursor position to jump back in the future
-        timeout = 3000, -- (optional) timeout for coc commands
+        timeout = 3000, -- timeout for coc commands
     }
   },
 })

--- a/lua/telescope/_extensions/coc.lua
+++ b/lua/telescope/_extensions/coc.lua
@@ -143,7 +143,7 @@ local function CocActionWithTimeout(type, ...)
 
   CocActionAsync(unpack(args))
 
-  local timeout = 3000
+  local timeout = (config and config.timeout) or 3000
   local waited = vim.wait(timeout, function()
     return completed
   end, 50)
@@ -703,6 +703,9 @@ return require('telescope').register_extension({
     end
     if ext_config.push_cursor_on_edit then
       config.push_cursor_on_edit = true
+    end
+    if ext_config.timeout then
+      config.timeout = ext_config.timeout
     end
   end,
   exports = {


### PR DESCRIPTION
Thank you for great extension! On my daily work, I work with big monorepo and sometimes I hit 3 seconds timeout for CoC commands when trying to find some references. It would be great to be able to configure timeout instead of having to rely on some arbitrary value.