### PR TITLE
fix: don't use `path_display` for document_symbols

### DIFF
--- a/lua/telescope/_extensions/coc.lua
+++ b/lua/telescope/_extensions/coc.lua
@@ -453,6 +453,7 @@ local document_symbols = function(opts)
   end
 
   opts.ignore_filename = opts.ignore_filename or true
+  opts.path_display = { "hidden" }
   pickers.new(opts, {
     prompt_title = 'Coc Document Symbols',
     previewer = conf.qflist_previewer(opts),


### PR DESCRIPTION
Currently, we're showing the filename first for the document_symbols when `path_display = { "filename_first" }`:
![image](https://github.com/user-attachments/assets/cc23e9ec-9115-4599-870b-9587b8fae745)

Telescope handles that for their `document_symbols` by setting `path_display = { "hidden" }`: https://github.com/nvim-telescope/telescope.nvim/blob/10b8a82b042caf50b78e619d92caf0910211973d/lua/telescope/builtin/__lsp.lua#L339

After doing the same here, the results are a lot better:
![image](https://github.com/user-attachments/assets/58b3cfdf-2bab-4989-af66-0347e242e605)
